### PR TITLE
Add out-of-cluster support

### DIFF
--- a/controllers/managedmcg_controller.go
+++ b/controllers/managedmcg_controller.go
@@ -96,6 +96,7 @@ func (r *ManagedMCGReconciler) initReconciler(req ctrl.Request) {
 	r.odfOperatorManagerconfigMap = &corev1.ConfigMap{}
 	r.odfOperatorManagerconfigMap.Name = odfOperatorManagerconfigMapName
 	r.odfOperatorManagerconfigMap.Namespace = r.namespace
+	r.odfOperatorManagerconfigMap.Data = make(map[string]string)
 
 	r.noobaa = &noobaa.NooBaa{}
 	r.noobaa.Name = noobaaName

--- a/shim/.env
+++ b/shim/.env
@@ -1,0 +1,6 @@
+CHANNEL=stable-4.9
+NAMESPACE=openshift-storage
+NOOBAA_CORE_IMAGE=noobaa/noobaa-core:5.10.0-20220120
+NOOBAA_DB_IMAGE=centos/postgresql-12-centos7
+ODF_IMAGE=quay.io/rhceph-dev/ocs-registry:latest-stable-4.9
+ADDON_NAME=mcg-deployer


### PR DESCRIPTION
Adds out-of-cluster support for the MCG deployer to allow it to run
locally, making the development iteration loop faster and also easier to
debug.

* Makefile includes a .env file, making all variables defined there
  accessible globally.
* Commands requiring any of these variables can specify them beforehand
  and make use of them.
* `Data` field was not instantiated in the ODF ConfigMap earlier.
  Nonetheless, we were able to run the deployer w/o any errors remotely,
  but not locally. This commit fixes that (thanks @v-harihar for
  pointing this out in #3!).