### PR TITLE
Modify test framwork as per new controller code

### DIFF
--- a/controllers/managedmcg_controller_test.go
+++ b/controllers/managedmcg_controller_test.go
@@ -18,15 +18,17 @@ package controllers
 
 import (
 	"context"
+	"os"
 	"testing"
 
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	noobaa "github.com/noobaa/noobaa-operator/v5/pkg/apis"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	promv1a1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	mcgv1alpha1 "github.com/red-hat-storage/mcg-osd-deployer/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,48 +38,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	CUSTOMER_NOTIFICATION_HTML_PATH = "/tmp/customernotification.html"
+)
+
 func newSchemeFake() *runtime.Scheme {
 	schemeFake := runtime.NewScheme()
-	schemes := []func(*runtime.Scheme) error{
-		clientgoscheme.AddToScheme,
-		noobaa.AddToScheme,
-		opv1a1.AddToScheme,
-		mcgv1alpha1.AddToScheme,
-		operatorv1.Install,
-	}
-	for _, f := range schemes {
-		if err := f(schemeFake); err != nil {
-			panic(err)
-		}
-	}
-
+	clientgoscheme.AddToScheme(schemeFake)
+	mcgv1alpha1.AddToScheme(schemeFake)
+	noobaa.AddToScheme(schemeFake)
+	opv1a1.AddToScheme(schemeFake)
+	operatorv1.Install(schemeFake)
+	promv1.AddToScheme(schemeFake)
+	promv1a1.AddToScheme(schemeFake)
 	return schemeFake
-}
-
-func newODFCSVFake() opv1a1.ClusterServiceVersion {
-	ODFCSVFake := opv1a1.ClusterServiceVersion{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "odf-operator",
-			Namespace: "openshift-storage",
-		},
-	}
-	ODFCSVFake.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = []opv1a1.StrategyDeploymentSpec{
-		{
-			Spec: v1.DeploymentSpec{
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: "manager",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return ODFCSVFake
 }
 
 func newManagedMCGFake() mcgv1alpha1.ManagedMCG {
@@ -91,33 +65,112 @@ func newManagedMCGFake() mcgv1alpha1.ManagedMCG {
 			ReconcileStrategy: "ignore",
 		},
 	}
-
 	return managedMCGFake
 }
 
+func newAddonSecretFake() corev1.Secret {
+	secretFake := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "AddOnSecretfake",
+			Namespace: "openshift-storage",
+		},
+	}
+	secretFake.Data = make(map[string][]byte, 1)
+	secretFake.Data["addonparam"] = []byte("foo")
+	return secretFake
+}
+
+func newPagerDutySecretFake() corev1.Secret {
+	secretFake := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "PagerDutySecretfake",
+			Namespace: "openshift-storage",
+		},
+	}
+	secretFake.Data = make(map[string][]byte, 1)
+	secretFake.Data["PAGERDUTY_KEY"] = []byte("foo")
+	return secretFake
+}
+
+func newDeadMansSecretFake() corev1.Secret {
+	secretFake := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "DeadMansSecretfake",
+			Namespace: "openshift-storage",
+		},
+	}
+	secretFake.Data = make(map[string][]byte, 1)
+	secretFake.Data["SNITCH_URL"] = []byte("foo")
+	return secretFake
+}
+
+func newSmtpSecretFake() corev1.Secret {
+	secretFake := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "SmtpSecretfake",
+			Namespace: "openshift-storage",
+		},
+	}
+	secretFake.Data = make(map[string][]byte, 1)
+	secretFake.Data["host"] = []byte("host")
+	secretFake.Data["port"] = []byte("8080")
+	secretFake.Data["username"] = []byte("username")
+	secretFake.Data["password"] = []byte("password")
+	return secretFake
+}
+func newOcsCsvFake() opv1a1.ClusterServiceVersion {
+	ocscsv := opv1a1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocs-operator",
+			Namespace: "openshift-storage",
+		},
+	}
+	return ocscsv
+}
+func cleanup() {
+	os.Remove(CUSTOMER_NOTIFICATION_HTML_PATH)
+}
 func TestManagedMCGReconcilerReconcile(t *testing.T) {
 	r := &ManagedMCGReconciler{}
 	r.Log = ctrl.Log.WithName("controllers").WithName("ManagedMCGFake")
+
 	r.Scheme = newSchemeFake()
-	r.initializeReconciler(reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      "managedmcgfake",
-			Namespace: "openshift-storage",
-		},
-	})
-	ODFCSVFake := newODFCSVFake()
+	ocscsvFake := newOcsCsvFake()
 	managedMCGFake := newManagedMCGFake()
-	fakeClient := fake.NewClientBuilder().WithScheme(r.Scheme).WithObjects(&ODFCSVFake, &managedMCGFake).Build()
+	addonsecretFake := newAddonSecretFake()
+	smtpsecretfake := newSmtpSecretFake()
+	pagerdutysecretFake := newPagerDutySecretFake()
+	deadmansercretFake := newDeadMansSecretFake()
+
+	r.AddonParamSecretName = "AddOnSecretfake"
+	r.DeadMansSnitchSecretName = "DeadMansSecretfake"
+	r.PagerdutySecretName = "PagerDutySecretfake"
+	r.SMTPSecretName = "SmtpSecretfake"
+	r.CustomerNotificationHTMLPath = CUSTOMER_NOTIFICATION_HTML_PATH
+
+	data := []byte{}
+	err := os.WriteFile(CUSTOMER_NOTIFICATION_HTML_PATH, data, 0444)
+	if err != nil {
+		t.Errorf("Can not create file : %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(r.Scheme).WithObjects(&ocscsvFake,
+		&smtpsecretfake, &addonsecretFake, &deadmansercretFake, &pagerdutysecretFake, &managedMCGFake).Build()
+
 	r.Client = fakeClient
 
 	r.Log.Info("Reconciling ManagedMCG object")
-	_, err := r.Reconcile(context.Background(), reconcile.Request{
+	_, err = r.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      "managedmcgfake",
 			Namespace: "openshift-storage",
 		},
 	})
 	if err != nil {
-		t.Errorf("ManagedMCGReconciler.Reconcile() error: %s", err)
+		t.Errorf("ManagedMCGReconciler.Reconcile() error: %v", err)
 	}
+	if err := r.removeNoobaa(); err != nil {
+		t.Errorf("Error while removing Nooba: %v", err)
+	}
+	cleanup()
 }


### PR DESCRIPTION
This patch includes following changes - 
1 - Removed the code ODF reconcile.
2 -Added code to update addon params.

What is missing in this patch?
This modification is not handling reconciliation of alert monitoring. This causes, the test to be failed in alert monitoring 
reconciliation. However an explicit function calls tests some other code too.

We still need to find how to avoid calling a function in a control flow during test if we do not want that code to be tested. 