### PR TITLE
Add fallback for GOBIN

### DIFF
--- a/hack/hooks/pre-commit
+++ b/hack/hooks/pre-commit
@@ -8,8 +8,9 @@ fi
 
 # Check if $GOBIN is set
 if [ -z "$(go env GOBIN)" ]; then
-  echo "GOBIN is not set"
-  exit 1
+  echo "GOBIN is not set, using GOPATH/bin"
+  GOBIN=$(go env GOPATH)/bin
+  export GOBIN
 fi
 
 # Check if golangci-lint binary is available


### PR DESCRIPTION
Openshift CI does not have the GOBIN env variable defined by default, in
that case fallback to GOPATH/bin.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>