### PR TITLE
Setup env-test binaries for coverage 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ARCH = $(shell go env GOARCH)
 all: manager
 
 # Estimate coverage
-coverage:
+coverage: test
 	go get golang.org/x/tools/cmd/cover
 	NOOBAA_CORE_IMAGE={NOOBAA_CORE_IMAGE} NOOBAA_DB_IMAGE={NOOBAA_DB_IMAGE} go test -coverprofile coverage.out ./...
 	go tool cover -func coverage.out


### PR DESCRIPTION
For the coverage target to work independent of other targets, include
the env-test framework setup step from the test target.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>