### PR TITLE
Revert "Don't suppress coverage logs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ testbin/*
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-coverage.*
 
 # Kubernetes Generated files - skip generated files, except for vendored files
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,7 @@ all: manager
 
 # Estimate coverage
 coverage: test
-	go tool cover -func coverage.out >> coverage.txt
-	cat coverage.txt
+	go tool cover -func coverage.out
 
 # Run linters
 lint:


### PR DESCRIPTION
Reverts red-hat-storage/mcg-osd-deployer#27

We don't need to explicitly `cat` another generated `.txt` file, since the logs are still recorded anyway: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/27907/rehearse-27907-pull-ci-red-hat-storage-mcg-osd-deployer-main-test-coverage/1522193561427120128/artifacts/test-coverage/test-coverage-aws/build-log.txt