### PR TITLE
Allow non-operator-sdk deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,10 @@ OPM = $(shell which opm)
 endif
 endif
 BUNDLE_IMGS ?= $(BUNDLE_IMG) 
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION) ifneq ($(origin CATALOG_BASE_IMG), undefined) FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG) endif 
+CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
+ifneq ($(origin CATALOG_BASE_IMG), undefined)
+	FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
+endif 
 .PHONY: catalog-build
 catalog-build: opm
 	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)

--- a/hack/deploy/catalogsource.yaml
+++ b/hack/deploy/catalogsource.yaml
@@ -1,0 +1,11 @@
+---
+kind: CatalogSource
+apiVersion: operators.coreos.com/v1alpha1
+metadata:
+  name: mcg-osd-deployer-catalog
+  namespace: redhat-data-federation
+spec:
+  image: quay.io/osd-addons/mcg-osd-dev:catalog-console-ci
+  displayName: CI
+  publisher: rexagod
+  sourceType: grpc

--- a/hack/deploy/namespace.yaml
+++ b/hack/deploy/namespace.yaml
@@ -1,0 +1,8 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  labels:
+    hive.openshift.io/managed: "true"
+    managed.openshift.io/storage-pv-quota-exempt: "true"
+  name: redhat-data-federation

--- a/hack/deploy/operatorgroup.yaml
+++ b/hack/deploy/operatorgroup.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: data-federation
+  namespace: redhat-data-federation
+spec:
+  targetNamespaces:
+    - redhat-data-federation

--- a/hack/deploy/secrets.yaml
+++ b/hack/deploy/secrets.yaml
@@ -1,0 +1,44 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+ name: mcg-osd-deadmanssnitch
+ namespace: redhat-data-federation
+stringData:
+ SNITCH_URL: https://nosnch.in/4a029adb4c
+type: Opaque
+---
+kind: Secret
+apiVersion: v1
+metadata:
+ name: mcg-osd-pagerduty
+ namespace: redhat-data-federation
+stringData:
+ PAGERDUTY_KEY: testKey
+type: Opaque
+---
+kind: Secret
+apiVersion: v1
+data:
+ host: c210cC5zZW5kZ3JpZC5uZXQ=
+ password: dGVzdC1wYXNzd29yZAo=
+ port: NTg3
+ tls: dHJ1ZQ==
+ username: YXBpa2V5
+metadata:
+ name: mcg-osd-smtp
+ namespace: redhat-data-federation
+type: Opaque
+---
+kind: Secret
+apiVersion: v1
+metadata:
+ name: addon-mcg-osd-parameters
+ namespace: redhat-data-federation
+ labels:
+   hive.openshift.io/managed: 'true'
+data:
+ notification-email-0: bmFwYXVsQHJlZGhhdC5jb20=
+ notification-email-1: bmFwYXVsQHJlZGhhdC5jb20=
+ notification-email-2: bmFwYXVsQHJlZGhhdC5jb20=
+type: Opaque


### PR DESCRIPTION
Supports deploying the addon without operator-sdk, for use in CI
environments (for `mcg-ms-console`).

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>