### PR TITLE
TLS PR follow ups

### DIFF
--- a/bundle/manifests/mcg-osd-deployer-k8s-metrics-sm-prometheus-k8s_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/mcg-osd-deployer-k8s-metrics-sm-prometheus-k8s_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
-  namespace: system
+  namespace: redhat-data-federation

--- a/bundle/manifests/mcg-osd-deployer-kube-rbac-proxy_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/mcg-osd-deployer-kube-rbac-proxy_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
-  namespace: system
+  namespace: redhat-data-federation

--- a/bundle/manifests/mcg-osd-deployer-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/mcg-osd-deployer-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: mcg-osd-deployer-controller-manager
-  namespace: mcg-osd-deployer-system
+  namespace: redhat-data-federation

--- a/bundle/manifests/mcg-osd-deployer-proxy-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/mcg-osd-deployer-proxy-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: mcg-osd-deployer-controller-manager
-  namespace: mcg-osd-deployer-system
+  namespace: redhat-data-federation

--- a/bundle/manifests/mcg.openshift.io_managedmcgs.yaml
+++ b/bundle/manifests/mcg.openshift.io_managedmcgs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: managedmcgs.mcg.openshift.io
 spec:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: mcg-osd-deployer-system
+namespace: redhat-data-federation
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,3 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+  - patch: '[{"op": "replace", "path": "/subjects/0/namespace", "value": "redhat-data-federation"}]'
+    target:
+      kind: ClusterRoleBinding
+      name: kube-rbac-proxy
+  - patch: '[{"op": "replace", "path": "/subjects/0/namespace", "value": "redhat-data-federation"}]'
+    target:
+      kind: ClusterRoleBinding
+      name: k8s-metrics-sm-prometheus-k8s
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:


### PR DESCRIPTION
Allow ClusterRoleBindings to utilize Kustomize for substituting namespaces.