### PR TITLE
uninstall flow delete all noobaa resources

### DIFF
--- a/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
@@ -340,6 +340,7 @@ spec:
           resources:
           - backingstores
           verbs:
+          - delete
           - get
           - list
           - watch
@@ -349,6 +350,16 @@ spec:
           - bucketclasses
           verbs:
           - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - noobaa.io
+          resources:
+          - namespacestores
+          verbs:
+          - delete
           - get
           - list
           - watch
@@ -363,6 +374,22 @@ spec:
           - list
           - update
           - watch
+        - apiGroups:
+          - objectbucket.io
+          resources:
+          - objectbucketclaims
+          verbs:
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - objectbucket.io
+          resources:
+          - objectbucketclaims/finalizers
+          verbs:
+          - update
         - apiGroups:
           - operators.coreos.com
           resources:

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
 - type: olm.package
   value:
     packageName: ose-prometheus-operator
-    version: "4.8.0"
+    version: "4.10.0"
 - type: olm.package
   value:
     packageName: mcg-operator

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
 - type: olm.package
   value:
     packageName: ose-prometheus-operator
-    version: "4.8.0"
+    version: "4.10.0"
 - type: olm.package
   value:
     packageName: mcg-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -196,6 +196,7 @@ rules:
   resources:
   - backingstores
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -205,6 +206,16 @@ rules:
   - bucketclasses
   verbs:
   - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - noobaa.io
+  resources:
+  - namespacestores
+  verbs:
+  - delete
   - get
   - list
   - watch
@@ -219,6 +230,22 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbucketclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbucketclaims/finalizers
+  verbs:
+  - update
 - apiGroups:
   - operators.coreos.com
   resources:

--- a/controllers/mcg_bucket.go
+++ b/controllers/mcg_bucket.go
@@ -35,7 +35,7 @@ const (
 func (r *ManagedMCGReconciler) watchBucketClass(object client.Object) {
 	bucketName := object.GetName()
 	annotations := object.GetAnnotations()
-	if _, ok := annotations[McgmsObcNamespace]; ok {
+	if _, ok := annotations[McgmsObcNamespace]; ok && r.isBucketClassCreationSuccess(object) {
 		r.objectBucketClaim = &noobaav1alpha1.ObjectBucketClaim{}
 		r.bucketClass = &noobaav1alpha1.BucketClass{}
 		if r.ctx == nil {
@@ -59,71 +59,7 @@ func (r *ManagedMCGReconciler) watchBucketClass(object client.Object) {
 
 			return
 		}
-		annotations := object.GetAnnotations()
-		if isCacheEnabled, ok := annotations[McgmsCacheEnabled]; ok && isCacheEnabled == "true" {
-			r.reconcileCacheBucketClass(object)
-		}
 	}
-}
-
-func (r *ManagedMCGReconciler) reconcileCacheBucketClass(object client.Object) {
-	r.Log.Info("Create Cache bucketClass for cache enabled namespacestores", "name", object.GetName())
-	bucketClass := r.setCacheBucketClassDesiredState(object)
-	if bucketClass == nil {
-		r.Log.Info("No Cache bucketClass returned for Cache enabled Bucket", "name", bucketClass.Name)
-
-		return
-	}
-	cacheBucketClassAnnotations := make(map[string]string)
-	cacheBucketClassAnnotations["cache-bucketclass"] = "true"
-	bucketClass.Name = object.GetName() + "-cache"
-	bucketClass.Namespace = r.namespace
-	bucketClass.ObjectMeta.Annotations = cacheBucketClassAnnotations
-	_, err := ctrl.CreateOrUpdate(r.ctx, r.Client, bucketClass, func() error {
-		r.Log.Info("creating/updating bucketClass CR", "name", bucketClass.Name)
-
-		return nil
-	})
-	if err != nil {
-		r.Log.Error(err, "Error while creating bucketClass, bucketClass not created")
-	}
-}
-
-func (r *ManagedMCGReconciler) setCacheBucketClassDesiredState(object client.Object) *noobaav1alpha1.BucketClass {
-	basebucketClass, ok := object.(*noobaav1alpha1.BucketClass)
-	if !ok {
-		return nil
-	}
-	r.Log.Info("Configure spec for Cache bucketClass", "name", basebucketClass.GetName())
-	defaultBackingStore := r.getDefaultBackingStore()
-	if defaultBackingStore == "" {
-		return nil
-	}
-	backingStoreName := defaultBackingStore
-	backingStores := []noobaav1alpha1.BackingStoreName{backingStoreName}
-	tier := noobaav1alpha1.Tier{
-		BackingStores: backingStores,
-	}
-	bucketClass := &noobaav1alpha1.BucketClass{
-		Spec: noobaav1alpha1.BucketClassSpec{
-			NamespacePolicy: &noobaav1alpha1.NamespacePolicy{
-				Type: noobaav1alpha1.NSBucketClassTypeCache,
-				Cache: &noobaav1alpha1.CacheNamespacePolicy{
-					HubResource: basebucketClass.Spec.NamespacePolicy.Single.Resource,
-					Caching: &noobaav1alpha1.CacheSpec{
-						TTL: 3600000,
-					},
-				},
-			},
-			PlacementPolicy: &noobaav1alpha1.PlacementPolicy{
-				Tiers: []noobaav1alpha1.Tier{
-					tier,
-				},
-			},
-		},
-	}
-
-	return bucketClass
 }
 
 func (r *ManagedMCGReconciler) getDefaultBackingStore() string {
@@ -133,6 +69,9 @@ func (r *ManagedMCGReconciler) getDefaultBackingStore() string {
 
 		return ""
 	}
+	if len(backingStores.Items) == 0 {
+		return ""
+	}
 	for _, backingStore := range backingStores.Items {
 		if strings.HasPrefix(backingStore.Name, DefaultBackingStore) {
 			return DefaultBackingStore
@@ -140,6 +79,19 @@ func (r *ManagedMCGReconciler) getDefaultBackingStore() string {
 	}
 
 	return backingStores.Items[0].Name
+}
+
+func (r *ManagedMCGReconciler) isBucketClassCreationSuccess(object client.Object) bool {
+	basebucketClass, ok := object.(*noobaav1alpha1.BucketClass)
+	if !ok {
+		return false
+	}
+	if basebucketClass.Status.Phase != "Ready" {
+		return false
+	}
+	r.Log.Info("BucketClass creation was success", "name", basebucketClass.Name)
+
+	return true
 }
 
 func (r *ManagedMCGReconciler) isOBCExists(object client.Object) bool {

--- a/hack/deploy/prometheus.yaml
+++ b/hack/deploy/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: downstream-prometheus-operator
+  namespace: redhat-data-federation
+spec:
+  displayName: downstream-prometheus-operator
+  image: quay.io/dbindra/ose-prometheus-operator:4.10.0_catsrc
+  publisher: RedHat
+  sourceType: grpc

--- a/readinessProbe/readiness/server.go
+++ b/readinessProbe/readiness/server.go
@@ -24,7 +24,9 @@ func isReady(client client.Client, managedMCGResource types.NamespacedName, log 
 
 		return false, fmt.Errorf("error while ensuring managedMCG: %w", err)
 	}
-	ready := managedMCG.Status.Components.Noobaa.State == v1.ComponentReady
+	ready := managedMCG.Status.Components.Noobaa.State == v1.ComponentReady &&
+		managedMCG.Status.Components.Prometheus.State == v1.ComponentReady &&
+		managedMCG.Status.Components.Alertmanager.State == v1.ComponentReady
 
 	return ready, nil
 }

--- a/templates/noobaa.go
+++ b/templates/noobaa.go
@@ -34,10 +34,10 @@ var NoobaaTemplate = &noobaa.NooBaa{
 				NumVolumes:   1,
 				VolumeResources: &v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceStorage: resource.MustParse("16Gi"),
+						v1.ResourceStorage: resource.MustParse("32Gi"),
 					},
 					Limits: v1.ResourceList{
-						v1.ResourceStorage: resource.MustParse("16Gi"),
+						v1.ResourceStorage: resource.MustParse("32Gi"),
 					},
 				},
 			},


### PR DESCRIPTION
PR will have:

uninstall flow will delete all the Noobaa resources before deleting the namespace
Noobaa default backing store size change
automatic cache BucakeClass reaction code removes
Noobaa CR will have defaultbackingstore name for Front end team
Prometheus version update
Signed-off-by: Naveen Paul @naveenpaul1