### PR TITLE
delete OCS resource only when nooba is ready

### DIFF
--- a/controllers/managedmcg_controller.go
+++ b/controllers/managedmcg_controller.go
@@ -590,6 +590,12 @@ func (r *ManagedMCGReconciler) reconcileNoobaaComponent() error {
 func (r *ManagedMCGReconciler) reconcileOCSCSV() error {
 	var csv *opv1a1.ClusterServiceVersion
 	var err error
+	subComponents := r.managedMCG.Status.Components
+	if subComponents.Noobaa.State != mcgv1alpha1.ComponentReady {
+		r.Log.Info("OCS resource deletion is waiting for Noobaa")
+
+		return nil
+	}
 	if csv, err = r.getCSVByPrefix("ocs-operator"); err != nil {
 		return err
 	}


### PR DESCRIPTION
fix for ocs-operator getting deleted before creating all the noobaa resources(SCC- noobaa, noobaa-endpoint) 

Sign off by : Naveen Paul @naveenpaul1 