### PR TITLE
Cardinality check for metrics

### DIFF
--- a/controllers/managedmcg_controller.go
+++ b/controllers/managedmcg_controller.go
@@ -107,6 +107,7 @@ type ManagedMCGReconciler struct {
 	addonParams                  map[string]string
 	alertmanager                 *promv1.Alertmanager
 	dmsRule                      *promv1.PrometheusRule
+	noobaaRules                  *promv1.PrometheusRule
 	prometheusProxyNetworkPolicy *netv1.NetworkPolicy
 	kubeRBACConfigMap            *v1.ConfigMap
 	prometheusService            *v1.Service
@@ -960,7 +961,6 @@ func (r *ManagedMCGReconciler) reconcileConsoleCluster() error {
 
 func (r *ManagedMCGReconciler) ensureConsolePlugin() error {
 	clusterVersion, err := r.determineOpenShiftVersion()
-
 	if err != nil {
 		return fmt.Errorf("failed to get the cluster version, %w", err)
 	}

--- a/controllers/noobaa-rules.yaml
+++ b/controllers/noobaa-rules.yaml
@@ -1,0 +1,105 @@
+ groups:
+   - name: noobaa-telemeter.rules
+     rules:
+       - expr: |
+           NooBaa_num_buckets_claims{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: noobaa_num_buckets_claims
+       - expr: |
+           NooBaa_num_unhealthy_bucket_claims{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: noobaa_num_unhealthy_bucket_claims
+       - expr: |
+           NooBaa_num_unhealthy_namespace_buckets{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: job:noobaa_total_unhealthy_namespace_buckets
+       - expr: |
+           NooBaa_num_namespace_buckets{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: job:noobaa_namespace_bucket_count
+       - expr: |
+           NooBaa_accounts_num{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: noobaa_accounts_num
+       - expr: |
+           NooBaa_total_usage{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: noobaa_total_usage
+       - expr: |
+            NooBaa_num_unhealthy_namespace_resources{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: noobaa_num_unhealthy_namespace_resources
+       - expr: |
+           NooBaa_num_namespace_resources{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: nooBaa_num_namespace_resources
+       - expr: |
+           NooBaa_namespace_resource_status{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: noobaa_namespace_resource_status
+       - expr: |
+           NooBaa_namespace_bucket_status{namespace="redhat-data-federation"}
+         labels:
+           origin: mcg-osd-deployer
+         record: noobaa_namespace_bucket_status
+   - name: noobaa-internal.rules
+     rules:
+       - expr: |
+           NooBaa_odf_health_status{namespace="redhat-data-federation"}
+         labels:
+           system_type: NooBaa
+           system_vendor: Red Hat
+           origin: mcg-osd-deployer
+         record: noobaa_system_health_status
+   - name: bucket-state-alert.rules
+     rules:
+       - alert: BucketPolicyErrorState
+         annotations:
+           description: A Bucket Policy {{ $labels.bucket_name }} is in error
+             state for more than 5m
+           message: A Bucket Policy Is In Error State
+           severity_level: warning
+           storage_type: NooBaa
+         expr: |
+           NooBaa_namespace_bucket_status{bucket_name=~".*"} == 0
+         for: 5m
+         labels:
+           severity: warning
+           origin: mcg-osd-deployer
+   - name: resource-state-alert.rules
+     rules:
+       - alert: CacheBucketErrorState
+         annotations:
+           description: The Cache Bucket {{ $labels.resource_name }} is in error state
+             for more than 5m
+           message: The Cache Bucket Is In Error State
+           severity_level: warning
+           storage_type: NooBaa
+         expr: |
+           NooBaa_resource_status{resource_name=~"noobaa-default-backing-store"} == 0
+         for: 5m
+         labels:
+           severity: warning
+           origin: mcg-osd-deployer
+       - alert: DataSourceErrorState
+         annotations:
+           description: A Data Source {{ $labels.namespace_resource_name
+             }} is in error state for more than 5m
+           message: A Data Source Is In Error State
+           severity_level: warning
+           storage_type: NooBaa
+         expr: |
+           NooBaa_namespace_resource_status{namespace_resource_name=~".*"} == 0
+         for: 5m
+         labels:
+           severity: warning
+           origin: mcg-osd-deployer

--- a/controllers/noobaa-rules.yaml
+++ b/controllers/noobaa-rules.yaml
@@ -4,52 +4,52 @@
        - expr: |
            NooBaa_num_buckets_claims{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_num_buckets_claims
        - expr: |
            NooBaa_num_unhealthy_bucket_claims{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_num_unhealthy_bucket_claims
        - expr: |
            NooBaa_num_unhealthy_namespace_buckets{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: job:noobaa_total_unhealthy_namespace_buckets
        - expr: |
            NooBaa_num_namespace_buckets{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: job:noobaa_namespace_bucket_count
        - expr: |
            NooBaa_accounts_num{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_accounts_num
        - expr: |
            NooBaa_total_usage{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_total_usage
        - expr: |
             NooBaa_num_unhealthy_namespace_resources{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_num_unhealthy_namespace_resources
        - expr: |
            NooBaa_num_namespace_resources{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: nooBaa_num_namespace_resources
        - expr: |
            NooBaa_namespace_resource_status{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_namespace_resource_status
        - expr: |
            NooBaa_namespace_bucket_status{namespace="redhat-data-federation"}
          labels:
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_namespace_bucket_status
    - name: noobaa-internal.rules
      rules:
@@ -58,7 +58,7 @@
          labels:
            system_type: NooBaa
            system_vendor: Red Hat
-           origin: mcg-osd-deployer
+           origin: data-federation-service
          record: noobaa_system_health_status
    - name: bucket-state-alert.rules
      rules:
@@ -74,7 +74,7 @@
          for: 5m
          labels:
            severity: warning
-           origin: mcg-osd-deployer
+           origin: data-federation-service
    - name: resource-state-alert.rules
      rules:
        - alert: CacheBucketErrorState
@@ -89,7 +89,7 @@
          for: 5m
          labels:
            severity: warning
-           origin: mcg-osd-deployer
+           origin: data-federation-service
        - alert: DataSourceErrorState
          annotations:
            description: A Data Source {{ $labels.namespace_resource_name
@@ -102,4 +102,4 @@
          for: 5m
          labels:
            severity: warning
-           origin: mcg-osd-deployer
+           origin: data-federation-service

--- a/hack/hooks/pre-commit
+++ b/hack/hooks/pre-commit
@@ -17,9 +17,10 @@ fi
 if ! command -v golangci-lint > /dev/null; then
   echo "golangci-lint is not installed, installing..."
   # Fetch golangci-lint binary
-  curl -sSfL \
+  curl -JL \
   https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
     sh -s -- -b "$(go env GOBIN)" v1.46.2
+  chmod +x "$(go env GOBIN)"/golangci-lint
 fi
 
 echo "[Running golangci-lint]"

--- a/hack/hooks/pre-commit
+++ b/hack/hooks/pre-commit
@@ -17,7 +17,9 @@ fi
 if ! command -v golangci-lint > /dev/null; then
   echo "golangci-lint is not installed, installing..."
   # Fetch golangci-lint binary
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOBIN)" latest
+  curl -sSfL \
+  https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+    sh -s -- -b "$(go env GOBIN)" v1.46.2
 fi
 
 echo "[Running golangci-lint]"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -67,6 +67,12 @@ func AddLabel(obj metav1.Object, key string, value string) {
 	labels[key] = value
 }
 
+// RemoveLabel removes a label from the resource metadata.
+func RemoveLabel(obj metav1.Object, key string) {
+	labels := obj.GetLabels()
+	delete(labels, key)
+}
+
 // GetRegexMatcher converts list of alerts to regex matcher.
 func GetRegexMatcher(alerts []string) string {
 	return "^" + strings.Join(alerts, "$|^") + "$"


### PR DESCRIPTION
Allow reduced cardinality for metrics, so that the overall influx of
data reaching data-hub's telemeter is minimal.
* introduces new wrapper metrics to avoid collision
* disallows parsing original noobaa rules and uses custom rules instead,
  to avoid conflict with products dependent on noobaa metrics, ODF, for
  instance.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>