### PR TITLE
Remove duplicate alerts

### DIFF
--- a/templates/alertmanagerconfig.go
+++ b/templates/alertmanagerconfig.go
@@ -36,14 +36,12 @@ func convertToAPIExtV1JSON(val interface{}) apiextensionsv1.JSON {
 var _false = false
 
 var pagerdutyAlerts = []string{
-	"DataSourceErrorState",
-	"BucketPolicyErrorState",
-	"CacheBucketErrorState",
+	"NooBaaCacheBucketErrorState",
 }
 
 var smtpAlerts = []string{
-	"DataSourceErrorState",
-	"BucketPolicyErrorState",
+	"NooBaaDataSourceErrorState",
+	"NooBaaBucketPolicyErrorState",
 }
 
 // OSD Full alerts are silenced as there is no scenario in our static deployment configuration where an OSD is getting


### PR DESCRIPTION
Remove duplicate alerts from PagerDuty, as this was causing the
duplicate alerts to be suppressed (no mails were recieved for them).