### PR TITLE
dfms-266 : Livenessprobe, readinessprobe missing for a few Data Federation containers

### DIFF
--- a/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
@@ -151,13 +151,13 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                   tcpSocket:
-                    port: 8443
+                    port: 8081
                 name: manager
                 readinessProbe:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                   tcpSocket:
-                    port: 8443
+                    port: 8081
                 resources:
                   limits:
                     cpu: 100m

--- a/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
@@ -114,11 +114,21 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+                livenessProbe:
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  tcpSocket:
+                    port: 8443
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
                   name: https
                   protocol: TCP
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  tcpSocket:
+                    port: 8443
                 resources:
                   limits:
                     cpu: 500m
@@ -137,7 +147,17 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 image: quay.io/osd-addons/mcg-osd:0.1.0
+                livenessProbe:
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  tcpSocket:
+                    port: 8443
                 name: manager
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  tcpSocket:
+                    port: 8443
                 resources:
                   limits:
                     cpu: 100m
@@ -153,6 +173,11 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 image: quay.io/osd-addons/mcg-osd:0.1.0
+                livenessProbe:
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  tcpSocket:
+                    port: 8081
                 name: readiness-server
                 readinessProbe:
                   httpGet:
@@ -184,12 +209,25 @@ spec:
             spec:
               containers:
               - image: quay.io/osd-addons/mcg-ms-console-dev:latest
+                livenessProbe:
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  tcpSocket:
+                    port: 9002
                 name: mcg-ms-console
                 ports:
                 - containerPort: 9002
                   protocol: TCP
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  tcpSocket:
+                    port: 9002
                 resources:
                   limits:
+                    cpu: 100m
+                    memory: 512Mi
+                  requests:
                     cpu: 100m
                     memory: 512Mi
                 volumeMounts:

--- a/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/mcg-osd-deployer.clusterserviceversion.yaml
@@ -148,16 +148,18 @@ spec:
                       fieldPath: metadata.namespace
                 image: quay.io/osd-addons/mcg-osd:0.1.0
                 livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8082
                   initialDelaySeconds: 15
                   periodSeconds: 20
-                  tcpSocket:
-                    port: 8081
                 name: manager
                 readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8082
                   initialDelaySeconds: 5
                   periodSeconds: 10
-                  tcpSocket:
-                    port: 8081
                 resources:
                   limits:
                     cpu: 100m

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -21,6 +21,9 @@ spec:
             limits:
               cpu: "100m"
               memory: "512Mi"
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
           ports:
             - containerPort: 9002
               protocol: TCP
@@ -34,13 +37,6 @@ spec:
             periodSeconds: 10
             tcpSocket:
               port: 9002
-                    resources:
-          limits:
-            cpu: 250m
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
           volumeMounts:
             - name: mcg-ms-console-serving-cert
               mountPath: /var/serving-cert

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -24,6 +24,23 @@ spec:
           ports:
             - containerPort: 9002
               protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            tcpSocket:
+              port: 9002
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            tcpSocket:
+              port: 9002
+                    resources:
+          limits:
+            cpu: 250m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
           volumeMounts:
             - name: mcg-ms-console-serving-cert
               mountPath: /var/serving-cert

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,6 +22,16 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          tcpSocket:
+            port: 8443
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 8443
         resources:
           limits:
             cpu: 500m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,12 +65,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
             tcpSocket:
-              port: 8443
+              port: 8081
           readinessProbe:
             initialDelaySeconds: 5
             periodSeconds: 10
             tcpSocket:
-              port: 8443
+              port: 8081
           resources:
             limits:
               cpu: 100m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,11 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            tcpSocket:
+              port: 8081
           resources:
             limits:
               cpu: 100m
@@ -56,6 +61,16 @@ spec:
             - --enable-leader-election
           image: controller:latest
           name: manager
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            tcpSocket:
+              port: 8443
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            tcpSocket:
+              port: 8443
           resources:
             limits:
               cpu: 100m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,15 +62,17 @@ spec:
           image: controller:latest
           name: manager
           livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
             initialDelaySeconds: 15
             periodSeconds: 20
-            tcpSocket:
-              port: 8081
           readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
-            tcpSocket:
-              port: 8081
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
- add Livenessprobe, readinessprobe, resource requests  limits for missing Data Federation containers

[DFMS-266](https://issues.redhat.com//browse/DFMS-266)[](https://issues.redhat.com/browse/DFMS-266)

Signoff by : @naveenpaul1 Naveen Paul